### PR TITLE
Fix auth sign up and auth forgot in style.css

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -92,7 +92,7 @@ function Layout() {
             modal={forgotModal}
             setModal={setForgotModal}
             width="524"
-            height="695"
+            height="467"
             element={<AuthForgot />}
           />
         ) : null}

--- a/components/common/CustomModal.tsx
+++ b/components/common/CustomModal.tsx
@@ -19,21 +19,6 @@ export const CustomModal = ({
   const disableModal = () => {
     setModal(false);
   };
-  // 모달 창이 나왔을때 백그라운드 클릭이 안되게 하고 스크롤도 고정하는 방법
-  useEffect(() => {
-    console.log('Loading');
-    console.log(document);
-    document.body.style.cssText = `
-  position: fixed; 
-  top: -${window.scrollY}px;
-  overflow: hidden;
-  width: 100%;`;
-    return () => {
-      const scrollY = document.body.style.top;
-      document.body.style.cssText = '';
-      window.scrollTo(0, parseInt(scrollY) * -1);
-    };
-  }, []);
 
   return (
     <>
@@ -53,7 +38,7 @@ const Container = styled.div<{ width: string; height: string }>`
   top: calc(50vh - ${(props) => props.height}px / 2);
   width: ${(props) => props.width}px;
   height: ${(props) => props.height}px;
-  /* padding: 8px; */
+  padding: 8px;
   background-color: white;
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05);
   z-index: 9999;

--- a/components/main/auth/Auth.tsx
+++ b/components/main/auth/Auth.tsx
@@ -78,16 +78,31 @@ const Auth = (): JSX.Element => {
     }
   }, [isRemember]);
 
+  useEffect(() => {
+    const html = document.documentElement;
+    if (closeLoginModal || signUpModal) {
+      html.style.overflowY = 'hidden';
+      html.style.overflowX = 'hidden';
+    } else {
+      html.style.overflowY = 'auto';
+      html.style.overflowX = 'auto';
+    }
+    return () => {
+      html.style.overflowY = 'auto';
+      html.style.overflowX = 'auto';
+    };
+  }, [closeLoginModal, signUpModal]);
+
   return (
     <LoginContainer className="modalBody" onClick={(e) => e.stopPropagation()}>
-      <StHeder
+      <Heder
         onClick={() => {
           setCloseLoginModal(!closeLoginModal);
         }}
       >
         {' '}
         〈 취소{' '}
-      </StHeder>
+      </Heder>
       <LoginTextDiv>
         <div>
           <b>픽스팟에 로그인</b> 하고, <br></br>
@@ -197,15 +212,19 @@ const Auth = (): JSX.Element => {
 const LoginContainer = styled.div`
   width: 100%;
   height: 100%;
+  margin-bottom: 50px;
 `;
-const StHeder = styled.header`
+const Heder = styled.header`
   cursor: pointer;
   color: #1882ff;
   font-size: 15px;
   display: flex;
+  margin-bottom: 50px;
+  margin-left: 20px;
 `;
 const LoginTextDiv = styled.div`
   margin-top: 0px;
+  margin-bottom: 10px;
   font-family: 'Noto Sans CJK KR';
   font-style: normal;
   font-size: 20px;
@@ -234,6 +253,7 @@ const AuthWarn = styled.p`
   color: red;
   font-size: 10px;
   height: 10px;
+  margin-left: 40px;
 `;
 const EditInputBox = styled.div`
   width: 100%;

--- a/components/main/auth/AuthForgot.tsx
+++ b/components/main/auth/AuthForgot.tsx
@@ -33,7 +33,7 @@ const AuthForgot = (): JSX.Element => {
 
   return (
     <ForgotPwContainer onClick={(e) => e.stopPropagation()}>
-      <StHeder
+      <Heder
         onClick={() => {
           setCloseLoginModal(!closeLoginModal);
           setForgotModal(!forgotModal);
@@ -41,7 +41,7 @@ const AuthForgot = (): JSX.Element => {
       >
         {' '}
         〈 돌아가기{' '}
-      </StHeder>
+      </Heder>
 
       {sent ? (
         <div>이미 당신의 이메일로 보냈습니다</div>
@@ -68,7 +68,7 @@ const AuthForgot = (): JSX.Element => {
               disabled={sending}
               onClick={() => resetPasswordRequest()}
             >
-              메일 전송 〉
+              메일 전송 {'〉'}
             </ResetPwBtn>
           </ResetContainer>
 
@@ -89,25 +89,29 @@ const AuthForgot = (): JSX.Element => {
 const ForgotPwContainer = styled.div`
   width: 100%;
   height: 100%;
+  /* margin-bottom: 50px; */
 `;
 
-const StHeder = styled.header`
+const Heder = styled.header`
   cursor: pointer;
   color: #1882ff;
   font-size: 15px;
   display: flex;
+  margin-bottom: 50px;
+  margin-left: 20px;
 `;
 
 const ForgotText = styled.div`
   margin-top: 30px;
+  margin-bottom: 30px;
   font-size: 20px;
   font-weight: 700;
-  margin-top: 5vh;
   text-align: center;
 `;
 
 const ResetContainer = styled.div`
-  width: 80%;
+  width: 394px;
+  height: 48px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -115,7 +119,6 @@ const ResetContainer = styled.div`
   border: 1px solid #8e8e93;
   margin: auto;
   margin-top: 40px;
-  height: 40px;
 `;
 
 const ResetPwForm = styled.form``;
@@ -125,7 +128,9 @@ const ResetPwInput = styled.input`
   height: 30px;
   border: 1px solid white;
   margin-left: 10px;
-  font-size: 10px;
+  font-family: 'Noto Sans CJK KR';
+  font-style: normal;
+  font-size: 13px;
 `;
 
 const ResetPwBtn = styled.button`
@@ -144,7 +149,6 @@ const LoginReturnButton = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 40px;
   border: transparent;
   transition: 0.1s;
   background-color: #8e8e93;
@@ -152,8 +156,10 @@ const LoginReturnButton = styled.button`
   font-size: 15px;
   cursor: pointer;
   margin: auto;
-  margin-top: 40px;
-  width: 80%;
+  margin-top: 90px;
+  margin-bottom: 50px;
+  width: 394px;
+  height: 48px;
 `;
 
 export default AuthForgot;

--- a/components/main/auth/AuthSignUp.tsx
+++ b/components/main/auth/AuthSignUp.tsx
@@ -93,7 +93,7 @@ const AuthSignUp = () => {
   };
   return (
     <SignUpContainer onClick={(e) => e.stopPropagation()}>
-      <StHeder
+      <Heder
         onClick={() => {
           setCloseLoginModal(!closeLoginModal);
           setSignUpModal(!signUpModal);
@@ -101,7 +101,7 @@ const AuthSignUp = () => {
       >
         {' '}
         〈 돌아가기{' '}
-      </StHeder>
+      </Heder>
 
       <SignUpTextDiv>회원가입하기</SignUpTextDiv>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -220,27 +220,27 @@ const AuthSignUp = () => {
 export default AuthSignUp;
 
 const SignUpContainer = styled.div`
-  /* background-color: #ffffff; */
   width: 100%;
   height: 100%;
-  /* padding: 30px 30px 30px 30px; */
-  /* box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.05); */
+  margin-bottom: 90px;
 `;
 
-const StHeder = styled.header`
+const Heder = styled.header`
   cursor: pointer;
   color: #1882ff;
   font-size: 15px;
   display: flex;
+  margin-bottom: 50px;
+  margin-left: 20px;
 `;
 
 const SignUpTextDiv = styled.div`
   display: flex;
   justify-content: center;
-  margin-top: 30px;
   font-size: 20px;
   font-weight: 700;
-  margin-top: 2vh;
+  margin-top: 10px;
+  margin-bottom: 60px;
 `;
 
 const SignUpEmailPwContainer = styled.form`
@@ -252,12 +252,14 @@ const SignUpEmailPwContainer = styled.form`
 `;
 
 const SignUpInput = styled.input`
-  height: 40px;
-  width: 96%;
-  padding-left: 10px;
-  background-color: #fbfbfb;
+  padding-left: 16px;
+  background-color: #f4f4f4;
   border: 1px solid #8e8e93;
   font-size: 15px;
+  display: flex;
+  width: 394px;
+  height: 48px;
+  margin: 0 auto;
 `;
 const EditInputBox = styled.div`
   width: 100%;
@@ -266,7 +268,7 @@ const EditInputBox = styled.div`
 const EditclearBtn = styled.div`
   position: absolute;
   top: 25%;
-  right: 12px;
+  right: 50px;
   width: 24px;
   height: 24px;
   background-image: url(/cancle-button.png);
@@ -277,7 +279,7 @@ const EditclearBtn = styled.div`
 const EditPwShowBtn = styled.div`
   position: absolute;
   top: 25%;
-  right: 12px;
+  right: 50px;
   width: 24px;
   height: 24px;
   background-image: url(/pw-show.png);
@@ -289,7 +291,7 @@ const AuthWarn = styled.p`
   color: red;
   font-size: 10px;
   height: 10px;
-  text-align: left;
+  margin-left: 40px;
 `;
 
 const SignUpBtnContainer = styled.div`
@@ -302,14 +304,18 @@ const SignUpBtnContainer = styled.div`
 
 const SignUpBtn = styled.button`
   display: flex;
+  width: 394px;
+  height: 48px;
+  margin: 0 auto;
+  flex-direction: row;
   justify-content: center;
   align-items: center;
-  height: 40px;
   border: transparent;
   transition: 0.1s;
   background-color: #1882ff;
   color: white;
   font-size: 15px;
+
   &:hover {
     cursor: pointer;
   }


### PR DESCRIPTION
### PR 타입 #1
Fix auth sign up and auth forgot in style.css

### 변경사항
모달 창 리코일 적용 후 CSS가 전부 틀어짐. 로그인, 회원가입, 비밀번호 찾기 모달 창을 다시 정렬함.
