### PR TITLE
Feat town category save

### DIFF
--- a/atom.tsx
+++ b/atom.tsx
@@ -47,3 +47,7 @@ export const editProfileModalAtom = atom({
   key: `editProfileModalAtom`,
   default: false,
 });
+export const townArray = atom({
+  key: 'townArray',
+  default: [],
+});

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,7 +10,7 @@ const Header = ({
   selectCity,
   onChangeSelectCity,
 }: {
-  selectCity: string | undefined;
+  selectCity: string | string[] | undefined;
   onChangeSelectCity: ChangeEventHandler<HTMLSelectElement> | undefined;
 }) => {
   const [currentUser, setCurrentUser] = useState(false);

--- a/components/main/TownSelect.tsx
+++ b/components/main/TownSelect.tsx
@@ -2,12 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 
-function TownSelect({
-  selectCity,
-  selectTown,
-  onClickSelectTown,
-  onChangeSelectTown,
-}: any) {
+function TownSelect({ selectCity, selectTown, onClickSelectTown }: any) {
   // console.log('selectTown : ', selectTown);
   const jejuTown = [
     '제주시 시내',
@@ -87,7 +82,7 @@ function TownSelect({
       </WebSelect>
       <MobileSelect>
         {selectCity === '제주시' ? (
-          <Select onChange={onChangeSelectTown} value={selectTown}>
+          <Select onChange={onClickSelectTown} value={selectTown}>
             <option value="">제주시 전체</option>
             {jejuTown.map((item: string) => (
               <TownOption key={uuidv4()} value={item}>
@@ -96,7 +91,7 @@ function TownSelect({
             ))}
           </Select>
         ) : selectCity === '서귀포시' ? (
-          <Select onChange={onChangeSelectTown} value={selectTown}>
+          <Select onChange={onClickSelectTown} value={selectTown}>
             <option value="">서귀포시 전체</option>
             {seogwipoTown.map((item: string) => (
               <TownOption key={uuidv4()} value={item}>
@@ -105,7 +100,7 @@ function TownSelect({
             ))}
           </Select>
         ) : (
-          <Select onChange={onChangeSelectTown} value={selectTown}>
+          <Select onChange={onClickSelectTown} value={selectTown}>
             <option value="">제주도 전체</option>
             {allTown.map((item: string) => (
               <TownOption key={uuidv4()} value={item}>


### PR DESCRIPTION
### PR 타입 #223 
타운 카테고리 유지

### 변경사항
상세페이지에서 메인페이지 이동 시, 선택했던 타운 카테고리들이 선택해제되는 현상을 수정하였습니다. (recoil state 사용)
사용하지 않는 코드를 삭제하였습니다.
selectCity state를 삭제하고, selectCity를 router.query.city로 대체하였습니다.
